### PR TITLE
Release 1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 Each new release typically also includes the latest modulesync defaults.
 These should not affect the functionality of the module.
 
+## [v1.3.0](https://github.com/lsst-it/puppet-kubectl/tree/v1.3.0) (2025-10-28)
+
+[Full Changelog](https://github.com/lsst-it/puppet-kubectl/compare/v1.2.0...v1.3.0)
+
+**Implemented enhancements:**
+
+- \(metadata.json\) Bump archiver to include v8 [\#39](https://github.com/lsst-it/puppet-kubectl/pull/39) ([badenerb](https://github.com/badenerb))
+- Update dependency voxpupuli-test to v13 [\#37](https://github.com/lsst-it/puppet-kubectl/pull/37) ([renovate[bot]](https://github.com/apps/renovate))
+- Update actions/labeler action to v6 [\#34](https://github.com/lsst-it/puppet-kubectl/pull/34) ([renovate[bot]](https://github.com/apps/renovate))
+- Update actions/checkout action to v5 [\#32](https://github.com/lsst-it/puppet-kubectl/pull/32) ([renovate[bot]](https://github.com/apps/renovate))
+
 ## [v1.2.0](https://github.com/lsst-it/puppet-kubectl/tree/v1.2.0) (2024-10-04)
 
 [Full Changelog](https://github.com/lsst-it/puppet-kubectl/compare/v1.1.0...v1.2.0)

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "lsst-kubectl",
-  "version": "1.2.1-rc0",
+  "version": "1.3.0",
   "author": "AURA/LSST/Rubin Observatory",
   "summary": "install kubectl",
   "license": "Apache-2.0",


### PR DESCRIPTION
Automated release-prep through https://github.com/voxpupuli/gha-puppet/ from commit 77a6b0dc8cb2e1b7b3d6f3203836831ba1f969c3.
Checkout the [module release instructions](https://voxpupuli.org/docs/releasing_version/).